### PR TITLE
Reservations

### DIFF
--- a/api/reservations.go
+++ b/api/reservations.go
@@ -1,12 +1,14 @@
 package api
 
 import (
+	"github.com/PPSKSY-Cluster/backend/auth"
 	"github.com/PPSKSY-Cluster/backend/db"
 	"github.com/gofiber/fiber/v2"
 	"go.mongodb.org/mongo-driver/bson/primitive"
 )
 
 func initReservationHandlers(reservationRouter fiber.Router) {
+	reservationRouter.Use(auth.CheckToken())
 	reservationRouter.Get("/", reservationListHandler())
 	reservationRouter.Get("/:id", reservationDetailHandler())
 	reservationRouter.Get("/?uId", reservationUserHandler())

--- a/api/router.go
+++ b/api/router.go
@@ -37,6 +37,9 @@ func InitRouter() (*fiber.App, error) {
 	cResourceRoutes := api.Group("/cresources")
 	initCResourceHandlers(cResourceRoutes)
 
+	reservationRoutes := api.Group("/reservations")
+	initReservationHandlers(reservationRoutes)
+
 	return router, nil
 }
 

--- a/db/reservationDBInterface.go
+++ b/db/reservationDBInterface.go
@@ -1,11 +1,12 @@
 package db
 
 import (
+	"os"
+	"time"
+
 	"go.mongodb.org/mongo-driver/bson"
 	"go.mongodb.org/mongo-driver/bson/primitive"
 	"go.mongodb.org/mongo-driver/mongo"
-	"os"
-	"time"
 )
 
 type Reservation struct {

--- a/db/reservationDBInterface.go
+++ b/db/reservationDBInterface.go
@@ -1,0 +1,193 @@
+package db
+
+import (
+	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/bson/primitive"
+	"go.mongodb.org/mongo-driver/mongo"
+	"os"
+	"time"
+)
+
+type Reservation struct {
+	ID        primitive.ObjectID `bson:"_id,omitempty" json:"_id,omitempty"`
+	ClusterID primitive.ObjectID `bson:"clusterID" json:"clusterID"`
+	UserID    primitive.ObjectID `bson:"userID" json:"userID"`
+	Nodes     int                `bson:"nodes" json:"nodes"`
+	StartTime int64              `bson:"startTime" json:"startTime"`
+	EndTime   int64              `bson:"endTime" json:"endTime"`
+	IsExpired bool               `bson:"isExpired" json:"isExpired"`
+}
+
+//TODO: Check whether or not reservations are expired!
+func GetAllReservations() ([]Reservation, error) {
+
+	query := func() (*mongo.Cursor, error) {
+		return mdbInstance.Client.
+			Database(os.Getenv("DB_NAME")).
+			Collection("reservations").
+			Find(mdbInstance.Ctx, bson.M{})
+	}
+
+	reservationCursor, err := runQuery[*mongo.Cursor](query)
+	if err != nil {
+		return nil, err
+	}
+
+	var reservations []Reservation
+	if err = reservationCursor.All(mdbInstance.Ctx, &reservations); err != nil {
+		return nil, err
+	}
+
+	for i := 0; i < len(reservations); i++ {
+		r := reservations[i]
+		r.IsExpired = CheckExpired(r)
+		reservations[i] = r
+	}
+
+	return reservations, nil
+}
+
+func GetReservationById(_id primitive.ObjectID) (Reservation, error) {
+
+	query := func() (*mongo.SingleResult, error) {
+		singleRes := mdbInstance.Client.
+			Database(os.Getenv("DB_NAME")).
+			Collection("reservations").
+			FindOne(mdbInstance.Ctx, bson.M{"_id": _id})
+		return singleRes, singleRes.Err()
+	}
+
+	reservationSingleRes, err := runQuery[*mongo.SingleResult](query)
+	if err != nil {
+		return Reservation{}, err
+	}
+
+	var reservation Reservation
+	if err = reservationSingleRes.Decode(&reservation); err != nil {
+		return Reservation{}, err
+	}
+
+	reservation.IsExpired = CheckExpired(reservation)
+
+	return reservation, nil
+}
+
+func GetReservationsByClusterId(clusterID primitive.ObjectID) ([]Reservation, error) {
+
+	query := func() (*mongo.Cursor, error) {
+		return mdbInstance.Client.
+			Database(os.Getenv("DB_NAME")).
+			Collection("reservations").
+			Find(mdbInstance.Ctx, bson.M{"clusterID": clusterID})
+	}
+
+	reservationCursor, err := runQuery[*mongo.Cursor](query)
+	if err != nil {
+		return nil, err
+	}
+
+	var reservations []Reservation
+	if err = reservationCursor.All(mdbInstance.Ctx, &reservations); err != nil {
+		return nil, err
+	}
+
+	for i := 0; i < len(reservations); i++ {
+		r := reservations[i]
+		r.IsExpired = CheckExpired(r)
+		reservations[i] = r
+	}
+
+	return reservations, nil
+}
+
+func GetReservationsByUserId(userID primitive.ObjectID) ([]Reservation, error) {
+
+	query := func() (*mongo.Cursor, error) {
+		return mdbInstance.Client.
+			Database(os.Getenv("DB_NAME")).
+			Collection("reservations").
+			Find(mdbInstance.Ctx, bson.M{"userID": userID})
+	}
+
+	reservationCursor, err := runQuery[*mongo.Cursor](query)
+	if err != nil {
+		return nil, err
+	}
+
+	var reservations []Reservation
+	if err = reservationCursor.All(mdbInstance.Ctx, &reservations); err != nil {
+		return nil, err
+	}
+
+	for i := 0; i < len(reservations); i++ {
+		r := reservations[i]
+		r.IsExpired = CheckExpired(r)
+		reservations[i] = r
+	}
+
+	return reservations, nil
+}
+
+func AddReservation(reservation Reservation) (Reservation, error) {
+
+	query := func() (*mongo.InsertOneResult, error) {
+		return mdbInstance.Client.
+			Database(os.Getenv("DB_NAME")).
+			Collection("reservations").
+			InsertOne(mdbInstance.Ctx, reservation)
+	}
+
+	//TODO:Find out what Validate actually does here/if its usable for reservations
+	if err := mdbInstance.Validate.Struct(reservation); err != nil {
+		return Reservation{}, err
+	}
+
+	insertRes, err := runQuery[*mongo.InsertOneResult](query)
+	if err != nil {
+		return Reservation{}, err
+	}
+
+	reservation.ID = insertRes.InsertedID.(primitive.ObjectID)
+
+	return reservation, nil
+}
+
+func EditReservation(_id primitive.ObjectID, reservation Reservation) (Reservation, error) {
+
+	query := func() (*mongo.UpdateResult, error) {
+		return mdbInstance.Client.
+			Database(os.Getenv("DB_NAME")).
+			Collection("reservations").
+			UpdateOne(mdbInstance.Ctx,
+				bson.M{"_id": _id},
+				bson.M{"$set": reservation})
+	}
+
+	_, err := runQuery[*mongo.UpdateResult](query)
+	if err != nil {
+		return Reservation{}, err
+	}
+
+	return reservation, nil
+}
+
+func DeleteReservation(_id primitive.ObjectID) error {
+
+	query := func() (*mongo.DeleteResult, error) {
+		return mdbInstance.Client.
+			Database(os.Getenv("DB_NAME")).
+			Collection("reservations").
+			DeleteOne(mdbInstance.Ctx, bson.M{"_id": _id})
+	}
+
+	_, err := runQuery[*mongo.DeleteResult](query)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func CheckExpired(reservation Reservation) bool {
+	return time.Now().After(time.UnixMicro(reservation.EndTime))
+}

--- a/db/reservationDBInterface.go
+++ b/db/reservationDBInterface.go
@@ -18,7 +18,6 @@ type Reservation struct {
 	IsExpired bool               `bson:"isExpired" json:"isExpired"`
 }
 
-//TODO: Check whether or not reservations are expired!
 func GetAllReservations() ([]Reservation, error) {
 
 	query := func() (*mongo.Cursor, error) {
@@ -137,7 +136,6 @@ func AddReservation(reservation Reservation) (Reservation, error) {
 			InsertOne(mdbInstance.Ctx, reservation)
 	}
 
-	//TODO:Find out what Validate actually does here/if its usable for reservations
 	if err := mdbInstance.Validate.Struct(reservation); err != nil {
 		return Reservation{}, err
 	}

--- a/tests/reservations_test.go
+++ b/tests/reservations_test.go
@@ -2,11 +2,12 @@ package tests
 
 import (
 	"fmt"
-	"github.com/PPSKSY-Cluster/backend/db"
-	"go.mongodb.org/mongo-driver/bson/primitive"
 	"os"
 	"testing"
 	"time"
+
+	"github.com/PPSKSY-Cluster/backend/db"
+	"go.mongodb.org/mongo-driver/bson/primitive"
 )
 
 func Test_reservations(t *testing.T) {
@@ -117,7 +118,7 @@ func Test_reservations(t *testing.T) {
 	executeTestReq[db.Reservation](t, app, deleteOneTest, tokenStr)
 
 	expiredAddTest := TestReq{
-		description:  "Add one already expired reservation (expect 200)",
+		description:  "Add one already expired reservation (expect 201)",
 		expectedCode: 201,
 		route:        "/api/reservations/",
 		method:       "POST",

--- a/tests/reservations_test.go
+++ b/tests/reservations_test.go
@@ -1,0 +1,139 @@
+package tests
+
+import (
+	"fmt"
+	"github.com/PPSKSY-Cluster/backend/db"
+	"go.mongodb.org/mongo-driver/bson/primitive"
+	"os"
+	"testing"
+	"time"
+)
+
+func Test_reservations(t *testing.T) {
+	fmt.Println("Testing reservations... ")
+	app, err := setupTestApplication()
+	if err != nil {
+		t.Error(err)
+	}
+	defer db.DropDB(os.Getenv("DB_NAME"))
+
+	user := db.User{Username: "foo", Password: "bar"}
+	tokenStr, createdUser := createUserAndLogin(t, app, user)
+
+	start := time.Now()
+	end := start.Add(time.Hour * 48)
+
+	foosReservation := db.Reservation{
+		ClusterID: primitive.NewObjectID(),
+		Nodes:     10,
+		UserID:    createdUser.ID,
+		StartTime: start.Unix(),
+		EndTime:   end.Unix(),
+		IsExpired: false,
+	}
+
+	start = start.Truncate(time.Hour * 24)
+	end = end.Truncate(time.Hour * 72)
+
+	expiredReservation := db.Reservation{
+		ClusterID: primitive.NewObjectID(),
+		Nodes:     10,
+		UserID:    createdUser.ID,
+		StartTime: start.Unix(),
+		EndTime:   end.Unix(),
+		IsExpired: false,
+	}
+
+	createOneTest := TestReq{
+		description:  "Create one Reservation (expect 201)",
+		expectedCode: 201,
+		route:        "/api/reservations/",
+		method:       "POST",
+		body:         foosReservation,
+		expectedData: foosReservation,
+	}
+	createdReservation := executeTestReq[db.Reservation](t, app, createOneTest, tokenStr)
+
+	getAllTest := TestReq{
+		description:  "Get all reservations (expect 200)",
+		expectedCode: 200,
+		route:        "/api/reservations/",
+		method:       "GET",
+		body:         nil,
+		expectedData: []db.Reservation{createdReservation},
+	}
+	executeTestReq[[]db.Reservation](t, app, getAllTest, tokenStr)
+
+	getAllClusterTest := TestReq{
+		description:  "Get all reservations with given cluster id (expect 200)",
+		expectedCode: 200,
+		route:        "/api/reservations/?cId=" + createdReservation.ClusterID.Hex(),
+		method:       "GET",
+		body:         nil,
+		expectedData: []db.Reservation{createdReservation},
+	}
+	executeTestReq[[]db.Reservation](t, app, getAllClusterTest, tokenStr)
+
+	getAllUserTest := TestReq{
+		description:  "Get all reservations with given uid (expect 200)",
+		expectedCode: 200,
+		route:        "/api/reservations/?uId=" + createdReservation.UserID.Hex(),
+		method:       "GET",
+		body:         nil,
+		expectedData: []db.Reservation{createdReservation},
+	}
+	executeTestReq[[]db.Reservation](t, app, getAllUserTest, tokenStr)
+
+	getOneTest := TestReq{
+		description:  "Get one reservation (expect 200)",
+		expectedCode: 200,
+		route:        "/api/reservations/" + createdReservation.ID.Hex(),
+		method:       "GET",
+		body:         nil,
+		expectedData: createdReservation,
+	}
+	executeTestReq[db.Reservation](t, app, getOneTest, tokenStr)
+
+	editedReservation := createdReservation
+	editedReservation.Nodes = 15
+	editOneTest := TestReq{
+		description:  "Edit one reservation (expect 200)",
+		expectedCode: 200,
+		route:        "/api/reservations/" + createdReservation.ID.Hex(),
+		method:       "PUT",
+		body:         editedReservation,
+		expectedData: editedReservation,
+	}
+	executeTestReq[db.Reservation](t, app, editOneTest, tokenStr)
+
+	deleteOneTest := TestReq{
+		description:  "Delete one reservation (expect 204)",
+		expectedCode: 204,
+		route:        "/api/reservations/" + createdReservation.ID.Hex(),
+		method:       "DELETE",
+		body:         nil,
+		expectedData: nil,
+	}
+	executeTestReq[db.Reservation](t, app, deleteOneTest, tokenStr)
+
+	expiredAddTest := TestReq{
+		description:  "Add one already expired reservation (expect 200)",
+		expectedCode: 201,
+		route:        "/api/reservations/",
+		method:       "POST",
+		body:         expiredReservation,
+		expectedData: expiredReservation,
+	}
+	expiredReservation = executeTestReq[db.Reservation](t, app, expiredAddTest, tokenStr)
+
+	expiredReservation.IsExpired = true
+	expiredGetTest := TestReq{
+		description:  "Retrieve expired reservation with isExpired now set to true (expect 200)",
+		expectedCode: 200,
+		route:        "/api/reservations/" + expiredReservation.ID.Hex(),
+		method:       "GET",
+		body:         nil,
+		expectedData: expiredReservation,
+	}
+	executeTestReq[db.Reservation](t, app, expiredGetTest, tokenStr)
+}


### PR DESCRIPTION
Resolves #23, #24, #25 

Created functionality that should be needed for reservations. Some endpoints might be unnecessary but getting every reservation for a given user/cluster seemed like a good idea. Reservations work with unix time stamps and everytime a reservation is requested the db checks whether or not it is expired -> Should get deleted after a while or from the get go, but I think this should be fine for now.
Might add functionality for checking if requested node amount is actually available later.