### PR TITLE
Fix user login after user editing

### DIFF
--- a/db/usersDBInterface.go
+++ b/db/usersDBInterface.go
@@ -20,7 +20,7 @@ const (
 type User struct {
 	ID       primitive.ObjectID `bson:"_id,omitempty" json:"_id,omitempty"`
 	Username string             `bson:"username" json:"username" validate:"required,min=3,max=20"`
-	Password string             `bson:"password" json:"password"`
+	Password string             `bson:"password,omitempty" json:"password,omitempty"`
 	Type     UserType           `bson:"type" json:"-"`
 }
 


### PR DESCRIPTION
resolves #63 
  - since the password wasn't omitted, it would always be set to the empty string on editing