### PR TITLE
Add authorization

### DIFF
--- a/api/c_resources.go
+++ b/api/c_resources.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"github.com/PPSKSY-Cluster/backend/auth"
 	"github.com/PPSKSY-Cluster/backend/db"
 	"github.com/gofiber/fiber/v2"
 	"go.mongodb.org/mongo-driver/bson/primitive"
@@ -9,6 +10,8 @@ import (
 func initCResourceHandlers(cresourceRouter fiber.Router) {
 	cresourceRouter.Get("/", cResourceListHandler())
 	cresourceRouter.Get("/:id", cResourceDetailHandler())
+
+	cresourceRouter.Use(auth.CheckToken(db.AdminUT))
 	cresourceRouter.Post("/", cResourceCreateHandler())
 	cresourceRouter.Put("/:id", cResourceUpdateHandler())
 	cresourceRouter.Delete("/:id", cResourceDeleteHandler())

--- a/api/reservations.go
+++ b/api/reservations.go
@@ -8,7 +8,7 @@ import (
 )
 
 func initReservationHandlers(reservationRouter fiber.Router) {
-	reservationRouter.Use(auth.CheckToken())
+	reservationRouter.Use(auth.CheckToken(db.UserUT))
 	reservationRouter.Get("/", reservationListHandler())
 	reservationRouter.Get("/:id", reservationDetailHandler())
 	reservationRouter.Get("/users/:uId", reservationUserHandler())

--- a/api/router.go
+++ b/api/router.go
@@ -57,7 +57,7 @@ func tokenCheckHandler() func(c *fiber.Ctx) error {
 		bearerStr := c.Get("Authorization")
 		_, err := auth.GetClaimsFromAccessToken(bearerStr)
 		if err != nil {
-			return c.SendStatus(401)
+			return fiber.NewError(fiber.StatusUnauthorized, err.Error())
 		}
 		return c.SendStatus(200)
 	}
@@ -105,12 +105,12 @@ func loginHandler() func(c *fiber.Ctx) error {
 		var login LoginPair
 
 		if err := c.BodyParser(&login); err != nil {
-			return c.SendStatus(500)
+			return fiber.NewError(fiber.StatusBadRequest, err.Error())
 		}
 
 		user, token, err := checkCredentialsF(login.Username, login.Password)
 		if err != nil {
-			return c.SendStatus(401)
+			return fiber.NewError(fiber.StatusUnauthorized, err.Error())
 		}
 
 		c.JSON(bson.M{"token": token, "user": user})

--- a/api/router.go
+++ b/api/router.go
@@ -33,9 +33,7 @@ func InitRouter() (*fiber.App, error) {
 	api.Post("/login", loginHandler())
 	api.Post("/refresh", refreshHandler())
 
-	tokenRoutes := api.Group("/token-check")
-	tokenRoutes.Use(auth.CheckToken())
-	tokenRoutes.Post("/", tokenCheckHandler())
+	api.Post("/token-check", tokenCheckHandler())
 
 	userRoutes := api.Group("/users")
 	initUserHandlers(userRoutes)
@@ -56,6 +54,11 @@ func InitRouter() (*fiber.App, error) {
 // @Router       /api/login [post]
 func tokenCheckHandler() func(c *fiber.Ctx) error {
 	return func(c *fiber.Ctx) error {
+		bearerStr := c.Get("Authorization")
+		_, err := auth.GetClaimsFromAccessToken(bearerStr)
+		if err != nil {
+			return c.SendStatus(401)
+		}
 		return c.SendStatus(200)
 	}
 }

--- a/api/users.go
+++ b/api/users.go
@@ -121,16 +121,18 @@ func userUpdateHandler() func(*fiber.Ctx) error {
 		}
 
 		// only super-admin or the user themself are allowed to edit
-		isSuperAdmin := c.Locals("jwtUserType") != db.SuperAdminUT
-		if id != c.Locals("jwtUserId") || !isSuperAdmin {
-			return c.SendStatus(401)
+		isSuperAdmin := c.Locals("jwtUserType") == db.SuperAdminUT
+		if id != c.Locals("jwtUserId") && !isSuperAdmin {
+			return fiber.NewError(fiber.StatusUnauthorized)
 		}
 
-		// only super admins may change the user type and only the user may
-		// change their PW
-		if isSuperAdmin {
+		// one may not change other users passwords
+		if id != c.Locals("jwtUserId") {
 			u.Password = ""
-		} else {
+		}
+
+		// only super admins may change user types
+		if !isSuperAdmin {
 			u.Type = c.Locals("jwtUserType").(db.UserType)
 		}
 

--- a/api/users.go
+++ b/api/users.go
@@ -10,7 +10,7 @@ import (
 func initUserHandlers(userRouter fiber.Router) {
 	userRouter.Post("/", userCreateHandler())
 
-	userRouter.Use(auth.CheckToken())
+	userRouter.Use(auth.CheckToken(db.UserUT))
 	userRouter.Get("/", userListHandler())
 	userRouter.Get("/:id", userDetailHandler())
 	userRouter.Put("/:id", userUpdateHandler())

--- a/api/users.go
+++ b/api/users.go
@@ -89,6 +89,7 @@ func userCreateHandler() func(*fiber.Ctx) error {
 		if err != nil {
 			return fiber.NewError(fiber.StatusInternalServerError, err.Error())
 		}
+		user.Password = ""
 
 		c.JSON(user)
 		return c.SendStatus(201)
@@ -123,7 +124,7 @@ func userUpdateHandler() func(*fiber.Ctx) error {
 			return fiber.NewError(fiber.StatusNotFound, err.Error())
 		}
 
-		user.ID = id
+		user.Password = ""
 		c.JSON(user)
 		return c.SendStatus(200)
 	}

--- a/api/users.go
+++ b/api/users.go
@@ -78,6 +78,7 @@ func userCreateHandler() func(*fiber.Ctx) error {
 		if err := c.BodyParser(u); err != nil {
 			return fiber.NewError(fiber.StatusBadRequest, err.Error())
 		}
+		u.Type = db.UserUT
 
 		hashedPW, err := auth.HashPW(u.Password)
 		if err != nil {
@@ -119,7 +120,31 @@ func userUpdateHandler() func(*fiber.Ctx) error {
 				"Could not convert given object ID, did you use the right ID-format?")
 		}
 
+		// only super-admin or the user themself are allowed to edit
+		isSuperAdmin := c.Locals("jwtUserType") != db.SuperAdminUT
+		if id != c.Locals("jwtUserId") || !isSuperAdmin {
+			return c.SendStatus(401)
+		}
+
+		// only super admins may change the user type and only the user may
+		// change their PW
+		if isSuperAdmin {
+			u.Password = ""
+		} else {
+			u.Type = c.Locals("jwtUserType").(db.UserType)
+		}
+
+		// if a user wants to change their PW, hash it first
+		if u.Password != "" {
+			u.Password, err = auth.HashPW(u.Password)
+			if err != nil {
+				return fiber.NewError(fiber.StatusBadRequest,
+					"Could not hash the given password : "+err.Error())
+			}
+		}
+
 		user, err := db.EditUser(id, *u)
+
 		if err != nil {
 			return fiber.NewError(fiber.StatusNotFound, err.Error())
 		}
@@ -144,6 +169,10 @@ func userDeleteHandler() func(*fiber.Ctx) error {
 		if err != nil {
 			return fiber.NewError(fiber.StatusBadRequest,
 				"Could not convert given object ID, did you use the right ID-format?")
+		}
+
+		if id != c.Locals("jwtUserId") {
+			return c.SendStatus(401)
 		}
 
 		err = db.DeleteUser(id)

--- a/api/users.go
+++ b/api/users.go
@@ -174,7 +174,7 @@ func userDeleteHandler() func(*fiber.Ctx) error {
 		}
 
 		if id != c.Locals("jwtUserId") {
-			return c.SendStatus(401)
+			return fiber.NewError(fiber.StatusUnauthorized)
 		}
 
 		err = db.DeleteUser(id)

--- a/auth/auth.go
+++ b/auth/auth.go
@@ -11,7 +11,6 @@ import (
 	"github.com/PPSKSY-Cluster/backend/db"
 	"github.com/dgrijalva/jwt-go"
 	"github.com/gofiber/fiber/v2"
-	"go.mongodb.org/mongo-driver/bson"
 	"go.mongodb.org/mongo-driver/bson/primitive"
 	"golang.org/x/crypto/bcrypt"
 )
@@ -96,13 +95,11 @@ func CheckToken(restrictedTo db.UserType) func(c *fiber.Ctx) error {
 		id, _ := primitive.ObjectIDFromHex(claims["userid"].(string))
 		user, err := db.GetUserById(id)
 		if err != nil {
-			c.JSON(bson.M{"Message": "Could not find user"})
-			return c.SendStatus(404)
+			return fiber.NewError(fiber.StatusNotFound, "Could not find user")
 		}
 
 		if !userTypeIncludes(user.Type, restrictedTo) {
-			c.JSON(bson.M{"Message": "Not authorized to access this route"})
-			return c.SendStatus(401)
+			return fiber.NewError(fiber.StatusUnauthorized, "Not authorized to access this route")
 		}
 
 		c.Locals("jwtUserId", user.ID)

--- a/auth/auth.go
+++ b/auth/auth.go
@@ -39,7 +39,7 @@ func InitAuth() error {
 	return nil
 }
 
-// Helper to generate a JWT token on login
+// Helper to generate a refresh JWT token on login
 func CheckCredentials() func(username, password string) (db.User, string, error) {
 	return func(username, password string) (db.User, string, error) {
 		user, err := db.GetUserWithCredentials(username)

--- a/auth/auth.go
+++ b/auth/auth.go
@@ -112,6 +112,9 @@ func CheckToken(restrictedTo db.UserType) func(c *fiber.Ctx) error {
 			return c.SendStatus(401)
 		}
 
+		c.Locals("jwtUserId", user.ID)
+		c.Locals("jwtUserType", user.Type)
+
 		return c.Next()
 	}
 }

--- a/db/testInterface.go
+++ b/db/testInterface.go
@@ -4,8 +4,39 @@
 // this file will not be included unless it's built for testing
 package db
 
+import (
+	"go.mongodb.org/mongo-driver/bson/primitive"
+	"go.mongodb.org/mongo-driver/mongo"
+	"os"
+)
+
 // this function is very dangerous because it drops the entire database
 // (which is a functionality we'd like to have for running tests)
 func DropDB(dbName string) {
 	mdbInstance.Client.Database(dbName).Drop(mdbInstance.Ctx)
+}
+
+// this allows to automatically create admins and super admins
+// for testing (just the first line of AddUser() is missing)
+func AddUserWithType(user User) (User, error) {
+	query := func() (*mongo.InsertOneResult, error) {
+		return mdbInstance.Client.
+			Database(os.Getenv("DB_NAME")).
+			Collection("users").
+			InsertOne(mdbInstance.Ctx, user)
+	}
+
+	if err := mdbInstance.Validate.Struct(user); err != nil {
+		return User{}, err
+	}
+
+	insertRes, err := runQuery[*mongo.InsertOneResult](query)
+	if err != nil {
+		return User{}, err
+	}
+
+	user.ID = insertRes.InsertedID.(primitive.ObjectID)
+	user.Password = ""
+
+	return user, nil
 }

--- a/db/usersDBInterface.go
+++ b/db/usersDBInterface.go
@@ -113,7 +113,6 @@ func AddUser(user User) (User, error) {
 	}
 
 	user.ID = insertRes.InsertedID.(primitive.ObjectID)
-	user.Password = ""
 
 	return user, nil
 }
@@ -131,8 +130,8 @@ func EditUser(_id primitive.ObjectID, user User) (User, error) {
 	if err != nil && updateRes.ModifiedCount != 1 {
 		return User{}, err
 	}
-	user.Password = ""
 
+	user.ID = _id
 	return user, nil
 }
 

--- a/db/usersDBInterface.go
+++ b/db/usersDBInterface.go
@@ -127,8 +127,8 @@ func EditUser(_id primitive.ObjectID, user User) (User, error) {
 			UpdateOne(mdbInstance.Ctx, bson.M{"_id": _id}, bson.M{"$set": user})
 	}
 
-	_, err := runQuery[*mongo.UpdateResult](query)
-	if err != nil {
+	updateRes, err := runQuery[*mongo.UpdateResult](query)
+	if err != nil && updateRes.ModifiedCount != 1 {
 		return User{}, err
 	}
 	user.Password = ""

--- a/db/usersDBInterface.go
+++ b/db/usersDBInterface.go
@@ -12,16 +12,16 @@ import (
 type UserType int
 
 const (
-	user       UserType = 0
-	admin      UserType = 1
-	superAdmin UserType = 2
+	UserUT       UserType = 0
+	AdminUT      UserType = 1
+	SuperAdminUT UserType = 2
 )
 
 type User struct {
 	ID       primitive.ObjectID `bson:"_id,omitempty" json:"_id,omitempty"`
 	Username string             `bson:"username" json:"username" validate:"required,min=3,max=20"`
 	Password string             `bson:"password,omitempty" json:"password,omitempty"`
-	Type     UserType           `bson:"type" json:"-"`
+	Type     UserType           `bson:"type" json:"type"`
 }
 
 var userDefaultProjection = bson.M{"password": 0}
@@ -94,6 +94,8 @@ func GetUserWithCredentials(username string) (User, error) {
 }
 
 func AddUser(user User) (User, error) {
+	user.Type = UserUT // may be edited later by other users
+
 	query := func() (*mongo.InsertOneResult, error) {
 		return mdbInstance.Client.
 			Database(os.Getenv("DB_NAME")).

--- a/tests/auth_test.go
+++ b/tests/auth_test.go
@@ -18,7 +18,7 @@ func Test_auth(t *testing.T) {
 
 	// create user and get a viable token
 	user := db.User{Username: "foo", Password: "bar"}
-	tokenStr, createdUser := createUserAndLogin(t, app, user)
+	tokenStr, createdUser := createUserAndLogin(t, app, user, false)
 
 	// use wrong pw
 	wrongPWUser := user

--- a/tests/c_resources_test.go
+++ b/tests/c_resources_test.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"testing"
 
+	"github.com/PPSKSY-Cluster/backend/auth"
 	"github.com/PPSKSY-Cluster/backend/db"
 )
 
@@ -17,9 +18,14 @@ func Test_cresources(t *testing.T) {
 	}
 	defer db.DropDB(os.Getenv("DB_NAME"))
 
-	// create user
-	user := db.User{Username: "foo", Password: "bar"}
-	tokenStr, createdUser := createUserAndLogin(t, app, user)
+	// create user with admin rights
+	user := db.User{Username: "foo", Password: "bar", Type: db.AdminUT}
+
+	userWithHashPw := user
+	userWithHashPw.Password, _ = auth.HashPW(user.Password)
+
+	createdUser, _ := db.AddUserWithType(userWithHashPw)
+	tokenStr, _ := auth.CheckCredentials()(user.Username, user.Password)
 
 	fooscResource := db.CResource{
 		Name:            "foos cresource",

--- a/tests/c_resources_test.go
+++ b/tests/c_resources_test.go
@@ -25,7 +25,7 @@ func Test_cresources(t *testing.T) {
 	userWithHashPw.Password, _ = auth.HashPW(user.Password)
 
 	createdUser, _ := db.AddUserWithType(userWithHashPw)
-	tokenStr, _ := auth.CheckCredentials()(user.Username, user.Password)
+	_, tokenStr, _ := auth.CheckCredentials()(user.Username, user.Password)
 
 	fooscResource := db.CResource{
 		Name:            "foos cresource",

--- a/tests/c_resources_test.go
+++ b/tests/c_resources_test.go
@@ -5,7 +5,6 @@ import (
 	"os"
 	"testing"
 
-	"github.com/PPSKSY-Cluster/backend/auth"
 	"github.com/PPSKSY-Cluster/backend/db"
 )
 
@@ -20,12 +19,7 @@ func Test_cresources(t *testing.T) {
 
 	// create user with admin rights
 	user := db.User{Username: "foo", Password: "bar", Type: db.AdminUT}
-
-	userWithHashPw := user
-	userWithHashPw.Password, _ = auth.HashPW(user.Password)
-
-	createdUser, _ := db.AddUserWithType(userWithHashPw)
-	_, tokenStr, _ := auth.CheckCredentials()(user.Username, user.Password)
+	tokenStr, createdUser := createUserAndLogin(t, app, user, true)
 
 	fooscResource := db.CResource{
 		Name:            "foos cresource",

--- a/tests/reservations_test.go
+++ b/tests/reservations_test.go
@@ -20,7 +20,7 @@ func Test_reservations(t *testing.T) {
 
 	//TODO: Change the mail endpoint!
 	user := db.User{Username: "foo", Password: "bar"}
-	tokenStr, createdUser := createUserAndLogin(t, app, user)
+	tokenStr, createdUser := createUserAndLogin(t, app, user, false)
 
 	start := time.Now()
 	end := start.Add(time.Minute * 3)

--- a/tests/test.go
+++ b/tests/test.go
@@ -161,6 +161,7 @@ func compare(t assert.TestingT, expectedData interface{}, data interface{}) {
 }
 
 func compareSlice(t assert.TestingT, expected reflect.Value, actual reflect.Value) {
+	assert.LessOrEqual(t, expected.Len(), actual.Len())
 	for i := 0; i < expected.Len(); i++ {
 		compareStruct(t, expected.Index(i), actual.Index(i))
 	}

--- a/tests/users_test.go
+++ b/tests/users_test.go
@@ -19,7 +19,7 @@ func Test_users(t *testing.T) {
 
 	// create user
 	user := db.User{Username: "foo", Password: "bar"}
-	tokenStr, createdUser := createUserAndLogin(t, app, user)
+	tokenStr, createdUser := createUserAndLogin(t, app, user, false)
 
 	editUser := db.User{ID: createdUser.ID, Username: "bar"}
 


### PR DESCRIPTION
resolves #40
resolves #51 

## Important changes/additions : 
In the jwt token, now we store the user id (if a compelling argument is made we can change it back, it just makes more sense to me).

User id from jwt token aswell as user type are now stored in fiber context locals for easy access in route handlers.

Also from [13ccb80](https://github.com/PPSKSY-Cluster/backend/pull/66/commits/13ccb80e15da1ee4c64095de1f9d4b6eff835d55) on where we should i.e. control when to return a PW (set it to empty string) or where we allow to set the user type : 
```
I think "what data part(s) do we want to add/get/modify/delete" is a question for handlers, 
not the db client. 
This way we keep the db more versatile and this behavior would't change for other dbs 
(=no reimplementation needed). 
Also for some things we will need authorization information, which we already have in our handlers 
(context locals) but would have to pass down for handling in db package
```